### PR TITLE
Multiple Fixes and Improvements for Auto-Buy and Auto-Build Features

### DIFF
--- a/paperclips.py
+++ b/paperclips.py
@@ -68,13 +68,10 @@ class PaperclipApp:
         if self.wire_auto_buy_enabled and self.wire == 0 and self.money >= self.wire_cost:
             self.money -= self.wire_cost
             self.wire += 1
-            self.update_labels()
-        elif self.wire >= 1:
+        if self.wire >= 1:
             self.paperclips += 1
             self.wire -= 1
             self.update_labels()
-        else:
-            return
 
     def check_wire_input(self, new_value):
         if new_value == "":

--- a/paperclips.py
+++ b/paperclips.py
@@ -56,10 +56,16 @@ class PaperclipApp:
         self.master.after(1000, self.update_auto_builders)
 
     def make_paperclip(self):
-        if self.wire >= 1:
+        if self.wire_auto_buy_enabled and self.wire == 0 and self.money >= self.wire_cost:
+            self.money -= self.wire_cost
+            self.wire += 1
+            self.update_labels()
+        elif self.wire >= 1:
             self.paperclips += 1
             self.wire -= 1
             self.update_labels()
+        else:
+            return
 
     def buy_wire(self):
         try:
@@ -74,22 +80,15 @@ class PaperclipApp:
             self.update_labels()
 
     def buy_wire_auto_check(self):
-        if not  self.wire_auto_buy_bought:
+        if not self.wire_auto_buy_bought:
             self.buy_auto_wire_buy()
             return
-        if not self.wire_auto_buy_enabled:
-            self.wire_auto_buy_enabled = True;
-            self.run_auto_buy_wire()
-        else:
-            self.wire_auto_buy_enabled = False;
-        self.update_labels()
-            
-    def run_auto_buy_wire(self):
-        if self.wire_auto_buy_enabled:
-            if self.wire == 0:
-                self.buy_wire()
-            self.master.after(20, self.run_auto_buy_wire)
 
+        if self.wire_auto_buy_enabled:
+            self.wire_auto_buy_enabled = False
+        else:
+            self.wire_auto_buy_enabled = True
+        self.update_labels()
             
     def buy_auto_wire_buy(self):
         cost = 200

--- a/paperclips.py
+++ b/paperclips.py
@@ -37,7 +37,11 @@ class PaperclipApp:
         self.wire_input = tk.Entry(self.master)
         self.wire_input.pack(pady=10)
 
-        self.buy_wire_button = tk.Button(self.master, text='Buy Wire', font=('Arial', 14), command=self.buy_wire)
+        vcmd = (self.master.register(self.check_wire_input), '%P')
+        self.wire_input.config(validate="key", validatecommand=vcmd)
+
+        self.buy_wire_button = tk.Button(
+            self.master, text='Buy Wire', font=('Arial', 14), command=self.buy_wire)
         self.buy_wire_button.pack(pady=10)
 
         self.auto_builder_label = tk.Label(self.master, text='Auto Builders: 0', font=('Arial', 16))
@@ -66,6 +70,16 @@ class PaperclipApp:
             self.update_labels()
         else:
             return
+
+    def check_wire_input(self, new_value):
+        if new_value == "":
+            return True
+
+        try:
+            int(new_value)
+            return True
+        except ValueError:
+            return False
 
     def buy_wire(self):
         try:

--- a/paperclips.py
+++ b/paperclips.py
@@ -16,19 +16,23 @@ class PaperclipApp:
 
         self.master.title('Universal Paperclips')
 
-        self.money_label = tk.Label(self.master, text='Money: $100', font=('Arial', 16))
+        self.money_label = tk.Label(
+            self.master, text=f'Money: ${self.money:.2f}', font=('Arial', 16))
         self.money_label.pack(pady=10)
 
-        self.paperclip_label = tk.Label(self.master, text='Paperclips: 0', font=('Arial', 16))
+        self.paperclip_label = tk.Label(
+            self.master, text=f'Paperclips: {self.paperclips}', font=('Arial', 16))
         self.paperclip_label.pack(pady=10)
 
-        self.wire_label = tk.Label(self.master, text='Wire: 0', font=('Arial', 16))
+        self.wire_label = tk.Label(
+            self.master, text=f'Wire: {self.wire}', font=('Arial', 16))
         self.wire_label.pack(pady=10)
 
         self.make_paperclip_button = tk.Button(self.master, text='Make Paperclip', font=('Arial', 14), command=self.make_paperclip)
         self.make_paperclip_button.pack(pady=10)
 
-        self.buy_wire_label = tk.Label(self.master, text=f'Buy Wire (Cost: ${self.wire_cost}/unit)', font=('Arial', 14))
+        self.buy_wire_label = tk.Label(
+            self.master, text=f'Buy Wire (Cost: ${self.wire_cost}/unit)', font=('Arial', 14))
         self.buy_wire_label.pack()
 
         self.auto_buy_wire_button = tk.Button(self.master, text=f"Buy Wire Auto $200", font=('Arial', 14), command=self.buy_wire_auto_check)
@@ -50,7 +54,8 @@ class PaperclipApp:
         self.buy_auto_builder_button = tk.Button(self.master, text=f'Buy Auto Builder (Cost: {self.auto_builder_cost} paperclips)', font=('Arial', 14), command=self.buy_auto_builder)
         self.buy_auto_builder_button.pack(pady=10)
 
-        self.sell_paperclip_button = tk.Button(self.master, text=f'Sell Paperclips ($0.1/pc)', font=('Arial', 14), command=self.sell_paperclips)
+        self.sell_paperclip_button = tk.Button(
+            self.master, text=f'Sell Paperclips (${self.paperclip_sell_price:.2f}/pc)', font=('Arial', 14), command=self.sell_paperclips)
         self.sell_paperclip_button.pack(pady=10)
 
         self.upgrade_paperclip_sell_button = tk.Button(self.master, text=f'Upgrade Paperclip Sell Price (Cost: ${self.paperclip_sell_upgrade_cost})', font=('Arial', 14), command=self.upgrade_paperclip_sell)

--- a/paperclips.py
+++ b/paperclips.py
@@ -150,7 +150,10 @@ class PaperclipApp:
     def update_labels(self):
         self.money_label.config(text=f'Money: ${self.money:.2f}')
         self.paperclip_label.config(text=f'Paperclips: {self.paperclips}')
-        self.wire_label.config(text=f'Wire: {self.wire}')
+        if self.wire_auto_buy_enabled:
+            self.wire_label.config(text=f'Auto-buy enabled! ({self.wire})')
+        else:
+            self.wire_label.config(text=f'Wire: {self.wire}')
         self.auto_builder_label.config(text=f'Auto Builders: {self.auto_builders}')
         self.sell_paperclip_button.config(text=f'Sell Paperclips (${self.paperclip_sell_price:.2f}/pc)')
         if self.wire_auto_buy_bought:

--- a/paperclips.py
+++ b/paperclips.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 
+
 class PaperclipApp:
     def __init__(self, master):
         self.master = master
@@ -10,7 +11,7 @@ class PaperclipApp:
         self.money = 500
         self.paperclip_sell_price = 1.01
         self.paperclip_sell_upgrade_cost = 50
-        self.wire_cost = 1;
+        self.wire_cost = 1
         self.wire_auto_buy_bought = False
         self.wire_auto_buy_enabled = False
 
@@ -28,14 +29,16 @@ class PaperclipApp:
             self.master, text=f'Wire: {self.wire}', font=('Arial', 16))
         self.wire_label.pack(pady=10)
 
-        self.make_paperclip_button = tk.Button(self.master, text='Make Paperclip', font=('Arial', 14), command=self.make_paperclip)
+        self.make_paperclip_button = tk.Button(self.master, text='Make Paperclip', font=(
+            'Arial', 14), command=self.make_paperclip)
         self.make_paperclip_button.pack(pady=10)
 
         self.buy_wire_label = tk.Label(
             self.master, text=f'Buy Wire (Cost: ${self.wire_cost}/unit)', font=('Arial', 14))
         self.buy_wire_label.pack()
 
-        self.auto_buy_wire_button = tk.Button(self.master, text=f"Buy Wire Auto $200", font=('Arial', 14), command=self.buy_wire_auto_check)
+        self.auto_buy_wire_button = tk.Button(self.master, text=f"Buy Wire Auto $200", font=(
+            'Arial', 14), command=self.buy_wire_auto_check)
         self.auto_buy_wire_button.pack()
 
         self.wire_input = tk.Entry(self.master)
@@ -48,20 +51,22 @@ class PaperclipApp:
             self.master, text='Buy Wire', font=('Arial', 14), command=self.buy_wire)
         self.buy_wire_button.pack(pady=10)
 
-        self.auto_builder_label = tk.Label(self.master, text='Auto Builders: 0', font=('Arial', 16))
+        self.auto_builder_label = tk.Label(
+            self.master, text='Auto Builders: 0', font=('Arial', 16))
         self.auto_builder_label.pack(pady=10)
 
-        self.buy_auto_builder_button = tk.Button(self.master, text=f'Buy Auto Builder (Cost: {self.auto_builder_cost} paperclips)', font=('Arial', 14), command=self.buy_auto_builder)
+        self.buy_auto_builder_button = tk.Button(self.master, text=f'Buy Auto Builder (Cost: {self.auto_builder_cost} paperclips)', font=(
+            'Arial', 14), command=self.buy_auto_builder)
         self.buy_auto_builder_button.pack(pady=10)
 
         self.sell_paperclip_button = tk.Button(
             self.master, text=f'Sell Paperclips (${self.paperclip_sell_price:.2f}/pc)', font=('Arial', 14), command=self.sell_paperclips)
         self.sell_paperclip_button.pack(pady=10)
 
-        self.upgrade_paperclip_sell_button = tk.Button(self.master, text=f'Upgrade Paperclip Sell Price (Cost: ${self.paperclip_sell_upgrade_cost})', font=('Arial', 14), command=self.upgrade_paperclip_sell)
+        self.upgrade_paperclip_sell_button = tk.Button(self.master, text=f'Upgrade Paperclip Sell Price (Cost: ${self.paperclip_sell_upgrade_cost})', font=(
+            'Arial', 14), command=self.upgrade_paperclip_sell)
         self.upgrade_paperclip_sell_button.pack(pady=10)
 
-    
         self.master.after(1000, self.update_auto_builders)
 
     def make_paperclip(self):
@@ -105,13 +110,13 @@ class PaperclipApp:
         else:
             self.wire_auto_buy_enabled = True
         self.update_labels()
-            
+
     def buy_auto_wire_buy(self):
         cost = 200
         if self.money < cost:
             return
         self.money -= cost
-        self.wire_auto_buy_bought = True;
+        self.wire_auto_buy_bought = True
         self.update_labels()
 
     def buy_auto_builder(self):
@@ -119,7 +124,8 @@ class PaperclipApp:
             self.paperclips -= self.auto_builder_cost
             self.auto_builders += 1
             self.auto_builder_cost *= 2
-            self.buy_auto_builder_button.config(text=f'Buy Auto Builder (Cost: {self.auto_builder_cost} paperclips)')
+            self.buy_auto_builder_button.config(
+                text=f'Buy Auto Builder (Cost: {self.auto_builder_cost} paperclips)')
             self.update_labels()
 
     def sell_paperclips(self):
@@ -133,16 +139,14 @@ class PaperclipApp:
             self.money -= self.paperclip_sell_upgrade_cost
             self.paperclip_sell_price *= 2
             self.paperclip_sell_upgrade_cost *= 2
-            self.upgrade_paperclip_sell_button.config(text=f'Upgrade Paperclip Sell Price (Cost: ${self.paperclip_sell_upgrade_cost})')
+            self.upgrade_paperclip_sell_button.config(
+                text=f'Upgrade Paperclip Sell Price (Cost: ${self.paperclip_sell_upgrade_cost})')
             self.update_labels()
 
     def update_auto_builders(self):
         for _ in range(self.auto_builders):
             self.make_paperclip()
         self.master.after(1000, self.update_auto_builders)
-
-
-
 
     def update_labels(self):
         self.money_label.config(text=f'Money: ${self.money:.2f}')
@@ -151,20 +155,22 @@ class PaperclipApp:
             self.wire_label.config(text=f'Auto-buy enabled! ({self.wire})')
         else:
             self.wire_label.config(text=f'Wire: {self.wire}')
-        self.auto_builder_label.config(text=f'Auto Builders: {self.auto_builders}')
-        self.sell_paperclip_button.config(text=f'Sell Paperclips (${self.paperclip_sell_price:.2f}/pc)')
+        self.auto_builder_label.config(
+            text=f'Auto Builders: {self.auto_builders}')
+        self.sell_paperclip_button.config(
+            text=f'Sell Paperclips (${self.paperclip_sell_price:.2f}/pc)')
         if self.wire_auto_buy_bought:
             if self.wire_auto_buy_enabled:
                 self.auto_buy_wire_button.config(text=f'Auto-buying wire')
             else:
                 self.auto_buy_wire_button.config(text=f'not Auto-buying wire')
 
+
 def main():
     root = tk.Tk()
     app = PaperclipApp(root)
     root.mainloop()
 
+
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
This pull request addresses several issues and improvements related to the auto-buy and auto-build functionalities:
- Fixed double render issue on auto-buy-paperclip.
- Added a wire count input check for better validation.
- Fixed an issue where labels on launch displayed static text instead of dynamic content.
- Updated the wire display to show auto-buyer status when enabled.
- Fixed a problem with auto-buy and auto-build not working properly together.
- Applied autopep8 linter for consistent code formatting.


These changes improve the overall functionality and user experience of the auto-buy and auto-build features in the application.
I suggest going trough commits one by one for easier reading.